### PR TITLE
build(MANGO-2756): :building_construction: removing loader-utils

### DIFF
--- a/json-url-loader/jsonUrlLoader.js
+++ b/json-url-loader/jsonUrlLoader.js
@@ -2,8 +2,19 @@
  * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
  */
 
-const loaderUtils = require('loader-utils');
 const jsonpointer = require('jsonpointer');
+
+const isUrlRequest = (value) => {
+    if (!value || typeof value !== 'string') return false;
+    // skip absolute URLs, data URIs and protocol-relative URLs
+    if (/^[a-z][a-z0-9+.-]*:/i.test(value) || value.startsWith('//')) return false;
+    return true;
+};
+
+const urlToRequest = (value) => {
+    if (!value.startsWith('.') && !value.startsWith('/')) return `./${value}`;
+    return value;
+};
 
 const defaultOptions = {
     parse: content => JSON.parse(content),
@@ -25,7 +36,7 @@ const loadModule = function(request) {
 };
 
 const transformUrl = function(value) {
-    const request = loaderUtils.urlToRequest(value);
+    const request = urlToRequest(value);
     return loadModule.call(this, request).then(({source, sourceMap, module}) => {
         const assets = module.buildInfo.assets;
         if (assets && Object.keys(assets).length) {
@@ -45,16 +56,16 @@ const transformUrl = function(value) {
  */
 const jsonUrlLoader = function(content, map, meta) {
     const callback = this.async();
-    const options = Object.assign({}, defaultOptions, loaderUtils.getOptions(this));
+    const options = Object.assign({}, defaultOptions, this.getOptions());
 
     const parsed = options.parse(content);
     const targets = typeof options.targets === 'function' ? options.targets(parsed) : options.targets;
 
     const promises = targets.map(p => {
         const value = jsonpointer.get(parsed, p);
-        if (loaderUtils.isUrlRequest(value)) {
+        if (isUrlRequest(value)) {
             return transformUrl.call(this, value).then(newValue => {
-                jsonpointer.set(parsed, options.publicPath + newValue);
+                jsonpointer.set(parsed, p, options.publicPath + newValue);
             });
         }
     });

--- a/module-tools/defaultPackage.json
+++ b/module-tools/defaultPackage.json
@@ -6,7 +6,7 @@
   "main": "",
   "dependencies": {},
   "devDependencies": {
-    "@radixiot/mango-module-tools": "^3.0.4"
+    "@radixiot/mango-module-tools": "^3.0.5"
   },
   "author": "Jared Wiltshire <jazdw@users.noreply.github.com>",
   "license": "UNLICENSED",

--- a/module-tools/module.config.js
+++ b/module-tools/module.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Radix IoT LLC. All rights reserved.
+ * Copyright (C) 2026 Radix IoT LLC. All rights reserved.
  */
 
 const path = require('path');
@@ -73,12 +73,15 @@ module.exports = (configOptions = {}) => {
                 })
             ],
             output: {
-                filename: '[name].js?v=[chunkhash]',
+                filename: '[name].js?v=[contenthash]',
+                clean: true,
                 path: path.resolve('web', 'angular'),
                 publicPath: `/modules/${moduleName}/web/angular/`,
-                libraryTarget: 'umd',
-                libraryExport: 'default',
-                library: moduleName
+                library: {
+                    type: 'umd',
+                    export: 'default',
+                    name: moduleName
+                }
             },
             externals: {
                 'angular': 'angular',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@radixiot/mango-module-tools",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Tools used for building and testing Mango Automation modules",
   "main": "./module-tools/module.config.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "css-loader": "^7.1.4",
     "html-loader": "^5.1.0",
     "jsonpointer": "^5.0.1",
-    "loader-utils": "^3.3.1",
     "lodash": "^4.17.23",
     "mocha": "^11.7.5",
     "style-loader": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "css-loader": "^7.1.4",
     "html-loader": "^5.1.0",
     "jsonpointer": "^5.0.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.0",
     "mocha": "^11.7.5",
     "style-loader": "^4.0.0",
     "webpack": "^5.105.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,11 +942,6 @@ loader-runner@^4.3.1:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.1.tgz#6c76ed29b0ccce9af379208299f07f876de737e3"
   integrity sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==
 
-loader-utils@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.3.1.tgz#735b9a19fd63648ca7adbd31c2327dfe281304e5"
-  integrity sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==
-
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,15 +304,15 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-baseline-browser-mapping@^2.9.0:
-  version "2.10.10"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz#e74bd066724c1d8d7d8ea75fc3be25389a7a5c56"
-  integrity sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==
+baseline-browser-mapping@^2.10.12:
+  version "2.10.13"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz#5a154cc4589193015a274e3d18319b0d76b9224e"
+  integrity sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==
 
 brace-expansion@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
+  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -322,15 +322,15 @@ browser-stdout@^1.3.1:
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
 browserslist@^4.28.1:
-  version "4.28.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
-  integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
   dependencies:
-    baseline-browser-mapping "^2.9.0"
-    caniuse-lite "^1.0.30001759"
-    electron-to-chromium "^1.5.263"
-    node-releases "^2.0.27"
-    update-browserslist-db "^1.2.0"
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -358,10 +358,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001759:
-  version "1.0.30001781"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz#344b47c03eb8168b79c3c158b872bcfbdd02a400"
-  integrity sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001784"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz#bdf9733a0813ccfb5ab4d02f2127e62ee4c6b718"
+  integrity sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==
 
 chai@^6.2.2:
   version "6.2.2"
@@ -530,10 +530,10 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-electron-to-chromium@^1.5.263:
-  version "1.5.325"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz#c2b3d510435a2b65dd65e891dde7eac0362edfb7"
-  integrity sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==
+electron-to-chromium@^1.5.328:
+  version "1.5.330"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz#0efe031938fc8fc82126162a7bd466ba7e24cd38"
+  integrity sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -956,10 +956,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash@^4.17.23:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@^4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
+  integrity sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -1077,7 +1077,7 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-releases@^2.0.27:
+node-releases@^2.0.36:
   version "2.0.36"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.36.tgz#99fd6552aaeda9e17c4713b57a63964a2e325e9d"
   integrity sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==
@@ -1492,7 +1492,7 @@ undici-types@~7.18.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
-update-browserslist-db@^1.2.0:
+update-browserslist-db@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
   integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==


### PR DESCRIPTION
Removing loader-utils which is not supported on webpack 4+. Module 'MangoUI' upgraded to use webpack5. 